### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-rfof-network.github.ton
+rfof-network.github.io


### PR DESCRIPTION
Repairing domain from rfof-network.github.ton to rfof-network.github.io 